### PR TITLE
Add sum API endpoint

### DIFF
--- a/index.py
+++ b/index.py
@@ -7,6 +7,13 @@ app = Flask(__name__)
 CORS(app, support_credentials=True)
 
 
+@app.route('/sum', methods=['POST'])
+def sum_numbers():
+    data = request.get_json()
+    num1 = data.get('num1')
+    num2 = data.get('num2')
+    result = add_numbers(num1, num2)
+    return jsonify({'sum': result})
 # Run the app at the specified port
 if __name__ == '__main__':
     app.run(port=8010, debug=True)


### PR DESCRIPTION
This change adds a new Flask API endpoint '/sum' that accepts a POST request with two numbers (num1 and num2) in the request body. It uses the 'add_numbers' function from utils.py to calculate the sum and returns the result as a JSON response.