### PR TITLE
Add ValueUpdated event to log storedValue changes

### DIFF
--- a/contract.sol
+++ b/contract.sol
@@ -4,13 +4,16 @@ pragma solidity ^0.8.0;
 contract SimpleStorage {
     uint256 public storedValue;
 
+    event ValueUpdated(uint256 oldValue, uint256 newValue, address indexed caller);
+
     constructor(uint256 _initialValue) {
         storedValue = _initialValue;
     }
 
     function setStoredValue(uint256 _newValue) public {
+        uint256 oldValue = storedValue;
         storedValue = _newValue;
-    }
+        emit ValueUpdated(oldValue, _newValue, msg.sender);
 
     function getStoredValue() public view returns (uint256) {
         return storedValue;


### PR DESCRIPTION
This PR adds a new event `ValueUpdated` that logs the old value, new value, and the address of the caller whenever the `setStoredValue` function is called. The `setStoredValue` function has been modified to emit this event after updating `storedValue`.