### PR TITLE
Add ValueUpdated event for storedValue changes

### DIFF
--- a/contract.sol
+++ b/contract.sol
@@ -3,13 +3,16 @@ pragma solidity ^0.8.0;
 
 contract SimpleStorage {
     uint256 public storedValue;
+	event ValueUpdated(uint256 oldValue, uint256 newValue, address indexed caller);
 
     constructor(uint256 _initialValue) {
         storedValue = _initialValue;
     }
 
-    function setStoredValue(uint256 _newValue) public {
-        storedValue = _newValue;
+	function setStoredValue(uint256 _newValue) public {
+		storedValue = _newValue;
+		emit ValueUpdated(oldValue, _newValue, msg.sender);
+		uint256 oldValue = storedValue;
     }
 
     function getStoredValue() public view returns (uint256) {


### PR DESCRIPTION
This commit introduces an event called `ValueUpdated`, which logs the old value, the new value, and the address of the caller each time the `storedValue` is updated. The `setStoredValue` function has been modified to emit this event every time it's called, ensuring that updates to the stored value are recorded on-chain with the relevant details.