### PR TITLE
Add Event Logging for storedValue Updates

### DIFF
--- a/contract.sol
+++ b/contract.sol
@@ -4,12 +4,16 @@ pragma solidity ^0.8.0;
 contract SimpleStorage {
     uint256 public storedValue;
 
+    event ValueUpdated(uint256 oldValue, uint256 newValue, address indexed caller);
+
     constructor(uint256 _initialValue) {
         storedValue = _initialValue;
     }
 
     function setStoredValue(uint256 _newValue) public {
+        uint256 oldValue = storedValue;
         storedValue = _newValue;
+        emit ValueUpdated(oldValue, _newValue, msg.sender);
     }
 
     function getStoredValue() public view returns (uint256) {


### PR DESCRIPTION
This PR adds a new event to log every time the storedValue is updated. The event will store the old value, the new value, and the address of the caller. Additionally, a new function is introduced to emit this event whenever the setStoredValue function is called.